### PR TITLE
fix: screen-welcome の position:relative を削除してキャラ切り替え画面の表示崩れを修正

### DIFF
--- a/artboard/prototype.html
+++ b/artboard/prototype.html
@@ -1209,7 +1209,6 @@
     justify-content: flex-start;
     padding: 0;
     min-height: 100%;
-    position: relative;
     overflow: hidden;
   }
 


### PR DESCRIPTION
screen-welcome と screen-switch がともに position:relative になると どちらも通常フローに入り、screen-switch が phone frame(812px)の
下方にはみ出して overflow:hidden でクリップされ、白紙になっていた。
screen-welcome からの position:relative を削除し、
.screen の position:absolute を継承させることで修正。

https://claude.ai/code/session_01UjD7ErgbkaKMyr4Kho43dV