### PR TITLE
prototype: はじめる画面のレイアウト調整

### DIFF
--- a/artboard/prototype.html
+++ b/artboard/prototype.html
@@ -1240,7 +1240,7 @@
     display: flex;
     justify-content: space-between;
     align-items: center;
-    padding: 16px 20px 0;
+    padding: 28px 20px 0;
     opacity: 0;
     animation: fadeUp var(--duration-normal) 0.1s var(--ease-enter) forwards;
   }
@@ -1573,13 +1573,7 @@
         <div class="wlc-service-label">SNS投稿のパーソナルアドバイザー</div>
         <div class="wlc-tagline">
           投稿のあとに、<br>
-          <span class="hl">待ってる</span>人が<br>
-          いる。
-        </div>
-        <div class="wlc-sub">
-          SNSデータを読み込んで、個性豊かな<br>
-          キャラクターが毎日フィードバック。<br>
-          3人から、あなたのアドバイザーを選んでください。
+          <span class="hl">待ってる</span>人がいる。
         </div>
       </div>
 


### PR DESCRIPTION
- topbar の上部余白を 16px → 28px に拡大
- タグラインの改行を修正：「待ってる人がいる。」を1行に収める
- タグライン下の説明テキストを削除（特徴リストと重複のため）

https://claude.ai/code/session_01UjD7ErgbkaKMyr4Kho43dV